### PR TITLE
Potential fix for code scanning alert no. 112: Missing origin verification in `postMessage` handler

### DIFF
--- a/packages/melviz-component-dev/src/index.tsx
+++ b/packages/melviz-component-dev/src/index.tsx
@@ -60,6 +60,12 @@ function handleDevConf(text: string) {
   );
 
   window.addEventListener("message", (e) => {
+    const allowedOrigin = window.location.origin;
+
+    if (e.origin !== allowedOrigin) {
+      return;
+    }
+
     const message = e.data as ComponentMessage;
     if (message.type === MessageType.FUNCTION_CALL) {
       respondFunctionCall(message);


### PR DESCRIPTION
Potential fix for [https://github.com/melviz-org/melviz/security/code-scanning/112](https://github.com/melviz-org/melviz/security/code-scanning/112)

In general, the fix is to verify that `event.origin` (and optionally `event.source`) matches a whitelist of trusted origins before acting on `event.data`. If the origin is not trusted, the handler should return without processing the message.

For this specific code, we can add an origin check inside the `"message"` event listener in `handleDevConf`. Since we cannot assume details of the rest of the code, the safest non-breaking approach is:

1. Derive an allowed origin from the current page (e.g. `window.location.origin`) so that only messages from the same origin are accepted. This preserves existing behaviour in typical same-origin dev setups.
2. Optionally allow `file:` usage by checking `e.origin === "null"` when the page is loaded from `file:` (common for some dev tools). If that’s not desired, we can skip this, but a same-origin check alone is already a significant improvement.
3. If `e.origin` does not match the allowed origin, return early and do not touch `e.data`.

We only need to modify the anonymous handler passed to `window.addEventListener("message", ...)` in `packages/melviz-component-dev/src/index.tsx`. No new imports or helper methods are strictly necessary; we can keep it self-contained.

Concretely, we will change:

```ts
  window.addEventListener("message", (e) => {
    const message = e.data as ComponentMessage;
    if (message.type === MessageType.FUNCTION_CALL) {
      respondFunctionCall(message);
    }
  });
```

to:

```ts
  window.addEventListener("message", (e) => {
    const allowedOrigin = window.location.origin;

    if (e.origin !== allowedOrigin) {
      return;
    }

    const message = e.data as ComponentMessage;
    if (message.type === MessageType.FUNCTION_CALL) {
      respondFunctionCall(message);
    }
  });
```

This ensures that only messages from the same origin as the dev page are processed, without changing the functional behaviour for legitimate same-origin usage.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
