### PR TITLE
Potential fix for code scanning alert no. 111: Missing origin verification in `postMessage` handler

### DIFF
--- a/packages/melviz-component-api/src/controller/BrowserComponentBus.ts
+++ b/packages/melviz-component-api/src/controller/BrowserComponentBus.ts
@@ -20,6 +20,11 @@ export class BrowserComponentBus implements ComponentBus {
   private listener: (message: ComponentMessage) => void;
 
   private readonly messageListener = (e: MessageEvent) => {
+    const trustedOrigin = window.location.origin;
+    if (e.origin !== trustedOrigin) {
+      // Ignore messages from untrusted origins
+      return;
+    }
     this.listener(e.data as ComponentMessage);
   };
 


### PR DESCRIPTION
Potential fix for [https://github.com/melviz-org/melviz/security/code-scanning/111](https://github.com/melviz-org/melviz/security/code-scanning/111)

In general, the fix is to ensure that the `"message"` event handler validates the origin (and optionally the source) of messages before acting on them. Only messages from a trusted origin (and possibly from an expected window/frame) should be forwarded to the bus.

The best way to fix this code without changing existing intended behavior is:

1. Determine the trusted origin dynamically from the current window. Since the sender uses `window.location.href` as `targetOrigin`, we can derive a trusted origin string from `window.location.origin`. This matches the scheme/host/port and avoids tying the check to an absolute URL.
2. Update `messageListener` to:
   - Compare `e.origin` to `window.location.origin`.
   - Optionally, ensure `e.source` is not `null` and is either `window.parent` or `window` itself. Because we don’t know the overall embedding model, we should keep this light and not exclude valid same-window messages; just checking `origin` is sufficient and safe.
   - Return early (ignore the event) if the origin does not match.
   - Optionally, ensure `e.data` structurally resembles a `ComponentMessage` before forwarding, but CodeQL’s issue is specifically about origin, so we keep changes minimal.

Concretely:

- In `packages/melviz-component-api/src/controller/BrowserComponentBus.ts`, modify the `private readonly messageListener` definition (line 22–24) to:
  - Compute `const trustedOrigin = window.location.origin;`
  - Check `if (e.origin !== trustedOrigin) { return; }`
  - Only then call `this.listener(e.data as ComponentMessage);`

No new imports or external libraries are needed; we can rely on the standard `window.location.origin` property that is supported in browsers where `postMessage` is available.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
